### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["laravel", "adminlte", "laratrust", "laravelcollective", "active", "admin"],
     "license": "MIT",
     "require": {
-        "illuminate/support": "^5.5",
+        "illuminate/support": "5.5.*",
         "laravelcollective/html": "^5.5",
         "santigarcor/laratrust": "^3.2",
         "hieu-le/active": "^3.4",


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.