### PR TITLE
Fixed group-id attribute on select2 being placed inside class attribute

### DIFF
--- a/src/resources/views/components/select2.blade.php
+++ b/src/resources/views/components/select2.blade.php
@@ -1,7 +1,7 @@
 @if(empty($name))
 <code>&lt;x-boilerplate::select2> The name attribute has not been set</code>
 @else
-<div class="form-group{{ isset($groupClass) ? ' '.$groupClass : '' }}{!! isset($groupId) ? ' id="'.$groupId.'"' : '' !!}">
+<div class="form-group{{ isset($groupClass) ? ' '.$groupClass : '' }}"{!! isset($groupId) ? ' id="'.$groupId.'"' : '' !!}>
 @isset($label)
     {{ Form::label($name, __($label)) }}
 @endisset


### PR DESCRIPTION
Moved quotation mark position to separate group-class and group-id attributes on select2 component