### PR TITLE
Fix problem with missing method on Laravel 11 for datatable generation

### DIFF
--- a/src/Console/Datatable.php
+++ b/src/Console/Datatable.php
@@ -117,7 +117,7 @@ class Datatable extends BoilerplateCommand
 
         foreach ($fields as $field) {
             if (! $this->option('nodb')) {
-                $type = $connection->getDoctrineColumn($model->getTable(), $field)->getType()->getName();
+                $type = $connection->getSchemaBuilder()->getColumnType($model->getTable(), $field);
             } else {
                 $type = preg_match('#_at$#', $field) ? 'datetime' : 'default';
             }


### PR DESCRIPTION
Fix issue with Doctrine new methods on Laravel 11.

This is related to https://github.com/laravel/framework/pull/48864 where the doctrine system was removed.

This fix contains the new method required.

Fixes #97 