### PR TITLE
Fix channel_hash_equals return type

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -39,7 +39,14 @@ if (! function_exists('channel_hash')) {
 }
 
 if (! function_exists('channel_hash_equals')) {
-    function channel_hash_equals($signature, ...$values): string
+    /**
+     * Check if the provided signature matches the generated one.
+     *
+     * @param  string  $signature
+     * @param  mixed  ...$values
+     * @return bool
+     */
+    function channel_hash_equals($signature, ...$values): bool
     {
         return $signature === md5(join('|', $values).config('app.key').config('app.url'));
     }


### PR DESCRIPTION
## Summary
- make `channel_hash_equals` return bool
- document boolean return in helper function

## Testing
- `make test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c2583234883338b0fc9df72ff3a05