### PR TITLE
Add channel hash helper tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -24,6 +24,9 @@
     <testsuite name="Datatables">
       <directory suffix="Test.php">./tests/Datatables</directory>
     </testsuite>
+    <testsuite name="Helpers">
+      <directory suffix="Test.php">./tests/Helpers</directory>
+    </testsuite>
     <testsuite name="Menu">
       <directory suffix="Test.php">./tests/Menu</directory>
     </testsuite>

--- a/tests/Helpers/ChannelHashTest.php
+++ b/tests/Helpers/ChannelHashTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Sebastienheyd\Boilerplate\Tests\Helpers;
+
+use Sebastienheyd\Boilerplate\Tests\TestCase;
+
+class ChannelHashTest extends TestCase
+{
+    public function testChannelHashGeneratesSignature()
+    {
+        $signature = md5('Notifications|1'.config('app.key').config('app.url'));
+        $expected = 'Notifications.1.'.$signature;
+
+        $this->assertEquals($expected, channel_hash('Notifications', 1));
+    }
+
+    public function testChannelHashEqualsSuccess()
+    {
+        $signature = md5('Notifications|1'.config('app.key').config('app.url'));
+
+        $this->assertTrue(channel_hash_equals($signature, 'Notifications', 1));
+    }
+
+    public function testChannelHashEqualsFailure()
+    {
+        $signature = md5('Notifications|2'.config('app.key').config('app.url'));
+
+        $this->assertFalse(channel_hash_equals($signature, 'Notifications', 1));
+    }
+}


### PR DESCRIPTION
## Summary
- add PHPUnit test covering channel hash helpers
- register Helpers testsuite in phpunit config

## Testing
- `make test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c275892248333b56f39c7eafa6bf8