### PR TITLE
feat(gpt): add multi-provider AI support for TinyMCE

### DIFF
--- a/src/Ai/AiProvider.php
+++ b/src/Ai/AiProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Sebastienheyd\Boilerplate\Ai;
+
+abstract class AiProvider
+{
+    protected string $slug;
+
+    protected string $label;
+
+    abstract public function isConfigured(): bool;
+
+    abstract public function endpoint(): string;
+
+    abstract public function headers(): array;
+
+    abstract public function body(string $prompt): array;
+
+    /**
+     * Parse a raw SSE data chunk.
+     * Returns text delta, null to skip, or '[DONE]' to signal end-of-stream.
+     */
+    abstract public function parseChunk(string $raw): ?string;
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+}

--- a/src/Ai/AiProvidersRepository.php
+++ b/src/Ai/AiProvidersRepository.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Sebastienheyd\Boilerplate\Ai;
+
+class AiProvidersRepository
+{
+    protected array $providers = [];
+
+    public function registerAiProvider(string ...$classes): static
+    {
+        foreach ($classes as $class) {
+            if (! is_subclass_of($class, AiProvider::class)) {
+                continue;
+            }
+            $provider = new $class;
+            $this->providers[$provider->getSlug()] = $provider;
+        }
+
+        return $this;
+    }
+
+    public function getProvider(string $slug): ?AiProvider
+    {
+        return $this->providers[$slug] ?? null;
+    }
+
+    public function getActiveProvider(): ?AiProvider
+    {
+        $slug = config('boilerplate.app.ai.default', 'openai');
+        $provider = $this->providers[$slug] ?? null;
+
+        return ($provider && $provider->isConfigured()) ? $provider : null;
+    }
+
+    public function hasConfiguredProvider(): bool
+    {
+        return $this->getActiveProvider() !== null;
+    }
+}

--- a/src/Ai/AiStreamer.php
+++ b/src/Ai/AiStreamer.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Sebastienheyd\Boilerplate\Ai;
+
+use Illuminate\Support\Facades\Log;
+
+class AiStreamer
+{
+    /**
+     * Stream AI provider response as normalized Server-Sent Events.
+     * Emits: data: {"content":"..."}\n\n  or  data: [DONE]\n\n
+     *
+     * @codeCoverageIgnore
+     */
+    public function stream(AiProvider $provider, string $prompt): void
+    {
+        $buffer = '';
+
+        $curl = curl_init();
+
+        curl_setopt_array($curl, [
+            CURLOPT_URL            => $provider->endpoint(),
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_ENCODING       => '',
+            CURLOPT_MAXREDIRS      => 10,
+            CURLOPT_TIMEOUT        => 0,
+            CURLOPT_FOLLOWLOCATION => true,
+            CURLOPT_HTTP_VERSION   => CURL_HTTP_VERSION_1_1,
+            CURLOPT_CUSTOMREQUEST  => 'POST',
+            CURLOPT_POSTFIELDS     => json_encode($provider->body($prompt)),
+            CURLOPT_HTTPHEADER     => $provider->headers(),
+            CURLOPT_WRITEFUNCTION  => function ($curl, $data) use ($provider, &$buffer) {
+                $buffer .= $data;
+
+                while (($pos = strpos($buffer, "\n")) !== false) {
+                    $line = substr($buffer, 0, $pos);
+                    $buffer = substr($buffer, $pos + 1);
+
+                    $line = trim($line);
+
+                    // Skip SSE event/comment lines and empty lines
+                    if ($line === '' || str_starts_with($line, 'event:') || str_starts_with($line, ':')) {
+                        continue;
+                    }
+
+                    // Strip "data: " prefix if present (OpenAI/Anthropic SSE format)
+                    $raw = str_starts_with($line, 'data: ') ? substr($line, 6) : $line;
+
+                    if ($raw === '[DONE]') {
+                        echo "data: [DONE]\n\n";
+                        ob_flush();
+                        flush();
+                        continue;
+                    }
+
+                    $delta = $provider->parseChunk($raw);
+
+                    if ($delta === '[DONE]') {
+                        echo "data: [DONE]\n\n";
+                        ob_flush();
+                        flush();
+                    } elseif ($delta !== null) {
+                        echo 'data: '.json_encode(['content' => $delta])."\n\n";
+                        ob_flush();
+                        flush();
+                    }
+                }
+
+                return strlen($data);
+            },
+        ]);
+
+        curl_exec($curl);
+        $err = curl_error($curl);
+        curl_close($curl);
+
+        if ($err) {
+            Log::error('AI provider cURL error: '.$err);
+        }
+    }
+}

--- a/src/Ai/AiStreamer.php
+++ b/src/Ai/AiStreamer.php
@@ -8,7 +8,7 @@ class AiStreamer
 {
     /**
      * Stream AI provider response as normalized Server-Sent Events.
-     * Emits: data: {"content":"..."}\n\n  or  data: [DONE]\n\n
+     * Emits: data: {"content":"..."}\n\n  or  data: [DONE]\n\n.
      *
      * @codeCoverageIgnore
      */

--- a/src/Ai/Providers/AnthropicProvider.php
+++ b/src/Ai/Providers/AnthropicProvider.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Sebastienheyd\Boilerplate\Ai\Providers;
+
+use Sebastienheyd\Boilerplate\Ai\AiProvider;
+
+class AnthropicProvider extends AiProvider
+{
+    protected string $slug = 'anthropic';
+
+    protected string $label = 'Anthropic Claude';
+
+    public function isConfigured(): bool
+    {
+        return ! empty(config('boilerplate.app.ai.providers.anthropic.key'));
+    }
+
+    public function endpoint(): string
+    {
+        return 'https://api.anthropic.com/v1/messages';
+    }
+
+    public function headers(): array
+    {
+        return [
+            'Content-Type: application/json',
+            'x-api-key: '.config('boilerplate.app.ai.providers.anthropic.key'),
+            'anthropic-version: 2023-06-01',
+        ];
+    }
+
+    public function body(string $prompt): array
+    {
+        return [
+            'model'      => config('boilerplate.app.ai.providers.anthropic.model', 'claude-3-5-haiku-20241022'),
+            'max_tokens' => 1024,
+            'stream'     => true,
+            'messages'   => [['role' => 'user', 'content' => $prompt]],
+        ];
+    }
+
+    public function parseChunk(string $raw): ?string
+    {
+        $obj = json_decode($raw);
+
+        if (! $obj) {
+            return null;
+        }
+
+        if (($obj->type ?? '') === 'message_stop') {
+            return '[DONE]';
+        }
+
+        if (($obj->type ?? '') === 'content_block_delta'
+            && ($obj->delta->type ?? '') === 'text_delta') {
+            return $obj->delta->text ?? null;
+        }
+
+        return null;
+    }
+}

--- a/src/Ai/Providers/OllamaProvider.php
+++ b/src/Ai/Providers/OllamaProvider.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Sebastienheyd\Boilerplate\Ai\Providers;
+
+use Sebastienheyd\Boilerplate\Ai\AiProvider;
+
+class OllamaProvider extends AiProvider
+{
+    protected string $slug = 'ollama';
+
+    protected string $label = 'Ollama';
+
+    public function isConfigured(): bool
+    {
+        return ! empty(config('boilerplate.app.ai.providers.ollama.model'));
+    }
+
+    public function endpoint(): string
+    {
+        $base = rtrim(config('boilerplate.app.ai.providers.ollama.endpoint', 'http://localhost:11434'), '/');
+
+        return $base.'/api/generate';
+    }
+
+    public function headers(): array
+    {
+        return ['Content-Type: application/json'];
+    }
+
+    public function body(string $prompt): array
+    {
+        return [
+            'model'  => config('boilerplate.app.ai.providers.ollama.model'),
+            'prompt' => $prompt,
+            'stream' => true,
+        ];
+    }
+
+    public function parseChunk(string $raw): ?string
+    {
+        $obj = json_decode($raw);
+
+        if (! $obj) {
+            return null;
+        }
+
+        if (! empty($obj->done)) {
+            return '[DONE]';
+        }
+
+        return $obj->response ?? null;
+    }
+}

--- a/src/Ai/Providers/OpenAiProvider.php
+++ b/src/Ai/Providers/OpenAiProvider.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Sebastienheyd\Boilerplate\Ai\Providers;
+
+use Sebastienheyd\Boilerplate\Ai\AiProvider;
+
+class OpenAiProvider extends AiProvider
+{
+    protected string $slug = 'openai';
+
+    protected string $label = 'OpenAI';
+
+    public function isConfigured(): bool
+    {
+        return ! empty(config('boilerplate.app.ai.providers.openai.key'))
+            || ! empty(config('boilerplate.app.openai.key'));
+    }
+
+    public function endpoint(): string
+    {
+        return 'https://api.openai.com/v1/chat/completions';
+    }
+
+    public function headers(): array
+    {
+        $key = config('boilerplate.app.ai.providers.openai.key')
+            ?: config('boilerplate.app.openai.key');
+
+        $headers = [
+            'Content-Type: application/json',
+            'Authorization: Bearer '.$key,
+        ];
+
+        $org = config('boilerplate.app.ai.providers.openai.organization')
+            ?: config('boilerplate.app.openai.organization');
+
+        if ($org) {
+            $headers[] = 'OpenAI-Organization: '.$org;
+        }
+
+        return $headers;
+    }
+
+    public function body(string $prompt): array
+    {
+        $model = config('boilerplate.app.ai.providers.openai.model')
+            ?: config('boilerplate.app.openai.model', 'gpt-4o-mini');
+
+        return [
+            'model'             => $model,
+            'messages'          => [['role' => 'user', 'content' => $prompt]],
+            'temperature'       => 0.6,
+            'frequency_penalty' => 0.52,
+            'presence_penalty'  => 0.5,
+            'max_tokens'        => 500,
+            'stream'            => true,
+        ];
+    }
+
+    public function parseChunk(string $raw): ?string
+    {
+        $obj = json_decode($raw);
+
+        if (! $obj) {
+            return null;
+        }
+
+        if (! empty($obj->error)) {
+            return null;
+        }
+
+        return $obj->choices[0]->delta->content ?? null;
+    }
+}

--- a/src/BoilerplateServiceProvider.php
+++ b/src/BoilerplateServiceProvider.php
@@ -232,6 +232,7 @@ class BoilerplateServiceProvider extends ServiceProvider
         $this->registerNavbarItems();
         $this->registerDatatables();
         $this->registerDashboardWidgets();
+        $this->registerAiProviders();
 
         Paginator::useBootstrap();
 
@@ -310,6 +311,19 @@ class BoilerplateServiceProvider extends ServiceProvider
             CurrentUser::class,
             UsersNumber::class,
             LatestErrors::class
+        );
+    }
+
+    private function registerAiProviders()
+    {
+        $this->app->singleton('boilerplate.ai.providers', function () {
+            return new Ai\AiProvidersRepository();
+        });
+
+        app('boilerplate.ai.providers')->registerAiProvider(
+            Ai\Providers\OpenAiProvider::class,
+            Ai\Providers\AnthropicProvider::class,
+            Ai\Providers\OllamaProvider::class
         );
     }
 }

--- a/src/Controllers/GptController.php
+++ b/src/Controllers/GptController.php
@@ -7,10 +7,10 @@ use Illuminate\Contracts\View\Factory;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\Str;
+use Sebastienheyd\Boilerplate\Ai\AiStreamer;
 
 class GptController
 {
@@ -149,7 +149,7 @@ class GptController
     }
 
     /**
-     * Stream the result from OpenAI API.
+     * Stream the AI provider response as Server-Sent Events.
      *
      * @param  Request  $request
      * @return void
@@ -168,86 +168,18 @@ class GptController
             exit;
         }
 
+        $provider = app('boilerplate.ai.providers')->getActiveProvider();
+
+        if (! $provider) {
+            abort(503);
+        }
+
         ini_set('max_execution_time', 90);
 
         header('Content-Type: text/event-stream');
         header('Cache-Control: no-cache');
 
-        $this->sendRequest($prompt, function ($curl, $data) {
-            $obj = json_decode($data);
-
-            if ($obj && ! empty($obj->error)) {
-                Log::error('OpenAI API Error : '.$obj->error->message.' '.$obj->error->code.' ('.$obj->error->type.')');
-            } else {
-                echo $data;
-            }
-
-            echo PHP_EOL;
-            ob_flush();
-            flush();
-
-            return strlen($data);
-        });
-    }
-
-    /**
-     * Send curl request to OpenAI Api.
-     *
-     * @param  $prompt
-     * @param  $callback
-     * @return bool|string
-     *
-     * @codeCoverageIgnore
-     */
-    private function sendRequest($prompt, $callback)
-    {
-        $curl = curl_init();
-
-        $data = [
-            'model'             => config('boilerplate.app.openai.model', 'gpt-3.5-turbo'),
-            'messages'          => [['role' => 'user', 'content' => $prompt]],
-            'temperature'       => 0.6,
-            'frequency_penalty' => 0.52,
-            'presence_penalty'  => 0.5,
-            'max_tokens'        => 500,
-            'stream'            => true,
-        ];
-
-        $headers = [
-            'Content-Type: application/json',
-            'Authorization: Bearer '.config('boilerplate.app.openai.key'),
-        ];
-
-        if (config('boilerplate.app.openai.organization')) {
-            $headers[] = 'OpenAI-Organization: '.config('boilerplate.app.openai.organization');
-        }
-
-        curl_setopt_array($curl, [
-            CURLOPT_URL            => 'https://api.openai.com/v1/chat/completions',
-            CURLOPT_RETURNTRANSFER => true,
-            CURLOPT_ENCODING       => '',
-            CURLOPT_MAXREDIRS      => 10,
-            CURLOPT_TIMEOUT        => 0,
-            CURLOPT_FOLLOWLOCATION => true,
-            CURLOPT_HTTP_VERSION   => CURL_HTTP_VERSION_1_1,
-            CURLOPT_CUSTOMREQUEST  => 'POST',
-            CURLOPT_POSTFIELDS     => json_encode($data),
-            CURLOPT_HTTPHEADER     => $headers,
-            CURLOPT_WRITEFUNCTION  => $callback,
-        ]);
-
-        $response = curl_exec($curl);
-        $err = curl_error($curl);
-
-        curl_close($curl);
-
-        if ($err) {
-            Log::error('OpenAI API Curl error : '.$err);
-
-            return 'OpenAI API Curl error : '.$err;
-        } else {
-            return $response;
-        }
+        app(AiStreamer::class)->stream($provider, $prompt);
     }
 
     /**

--- a/src/View/Composers/TinymceLoadComposer.php
+++ b/src/View/Composers/TinymceLoadComposer.php
@@ -13,5 +13,7 @@ class TinymceLoadComposer extends ComponentComposer
         // Check if sebastienheyd/boilerplate-media-manager is installed
         $providers = app()->getProviders('Sebastienheyd\BoilerplateMediaManager\ServiceProvider');
         $view->with('hasMediaManager', ! empty($providers));
+
+        $view->with('aiEnabled', app('boilerplate.ai.providers')->hasConfiguredProvider());
     }
 }

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -22,8 +22,29 @@ return [
     // If true, the session will be kept alive and the user must log out
     'keepalive'         => true,
 
-    // Allows to generate text with ChatGPT in TinyMCE
-    'openai'   => [
+    // AI provider for text generation in TinyMCE (openai, anthropic, ollama, or custom slug)
+    'ai' => [
+        'default' => env('AI_PROVIDER', 'openai'),
+
+        'providers' => [
+            'openai' => [
+                'key'          => env('OPENAI_API_KEY'),
+                'model'        => env('OPENAI_MODEL', 'gpt-4o-mini'),
+                'organization' => env('OPENAI_API_ORGANIZATION'),
+            ],
+            'anthropic' => [
+                'key'   => env('ANTHROPIC_API_KEY'),
+                'model' => env('ANTHROPIC_MODEL', 'claude-3-5-haiku-20241022'),
+            ],
+            'ollama' => [
+                'endpoint' => env('OLLAMA_ENDPOINT', 'http://localhost:11434'),
+                'model'    => env('OLLAMA_MODEL', ''),
+            ],
+        ],
+    ],
+
+    // Kept for backward compatibility — OpenAiProvider falls back to this if ai.providers.openai.key is empty
+    'openai' => [
         'key'          => env('OPENAI_API_KEY'),
         'model'        => 'gpt-4o-mini',
         'organization' => env('OPENAI_API_ORGANIZATION'),

--- a/src/resources/assets/js/vendor/tinymce/plugins/gpt/generator.js
+++ b/src/resources/assets/js/vendor/tinymce/plugins/gpt/generator.js
@@ -67,7 +67,7 @@ $(function() {
                             $('#buttons, #copy, #confirm').show();
                             eventSource.close();
                         } else {
-                            let txt = JSON.parse(e.data).choices[0].delta.content
+                            let txt = JSON.parse(e.data).content
                             if (txt !== undefined) {
                                 txt = txt.replace(/(?:\r\n|\r|\n)/g, '<br>');
                                 txt = txt.replace(/"/g, '')

--- a/src/resources/views/load/tinymce.blade.php
+++ b/src/resources/views/load/tinymce.blade.php
@@ -4,7 +4,7 @@
     <script src="{!! mix('/plugins/tinymce/tinymce.min.js', '/assets/vendor/boilerplate') !!}"></script>
     <script>
         tinymce.defaultSettings = {
-            plugins: "autoresize fullscreen codemirror link lists table media image imagetools paste customalign{{ config('boilerplate.app.openai.key') ? ' gpt' : '' }}",
+            plugins: "autoresize fullscreen codemirror link lists table media image imagetools paste customalign{{ $aiEnabled ? ' gpt' : '' }}",
             toolbar: "undo redo | styleselect | bold italic underline | customalignleft aligncenter customalignright | gpt link media image | bullist numlist | table | code fullscreen",
             contextmenu: "link image imagetools table spellchecker bold italic underline",
             toolbar_drawer: "sliding",
@@ -23,7 +23,7 @@
             encoding: 'UTF-8',
             image_uploadtab: false,
             deprecation_warnings: false,
-            @if(config('boilerplate.app.openai.key'))
+            @if($aiEnabled)
             gpt: {
                 'tooltip': "@lang('boilerplate::gpt.tooltip')",
                 'title': "@lang('boilerplate::gpt.title')",

--- a/src/routes/boilerplate.php
+++ b/src/routes/boilerplate.php
@@ -128,8 +128,8 @@ Route::group([
             Route::delete('sessions/{sessionId}', [UsersController::class, 'disconnectSession'])->name('session.disconnect');
         });
 
-        // ChatGPT
-        if (config('boilerplate.app.openai.key')) {
+        // AI text generation
+        if (app('boilerplate.ai.providers')->hasConfiguredProvider()) {
             Route::prefix('gpt')->as('gpt.')->group(function () {
                 Route::get('/', [GptController::class, 'index'])->name('index');
                 Route::post('/', [GptController::class, 'process'])->name('process');


### PR DESCRIPTION
## Summary

Refactor the hardcoded OpenAI integration into an extensible multi-provider architecture supporting OpenAI, Anthropic Claude, Ollama, and custom providers.

- **New architecture**: Abstract `AiProvider` base class with `AiProvidersRepository` singleton (follows existing pattern from `DashboardWidgetsRepository`)
- **New providers**: OpenAI, Anthropic Claude, Ollama built-in; custom providers extensible
- **Normalized streaming**: All providers emit unified SSE format `{"content":"..."}` for frontend compatibility
- **Backward compatible**: Existing OpenAI config still works; new multi-provider config optional
- **Configuration**: Set `AI_PROVIDER=openai|anthropic|ollama` in `.env`, or register custom providers

## Changes

### New files
- `src/Ai/AiProvider.php` — abstract base class
- `src/Ai/AiProvidersRepository.php` — registry singleton
- `src/Ai/AiStreamer.php` — provider-agnostic cURL + SSE handler
- `src/Ai/Providers/OpenAiProvider.php` — with legacy config fallback
- `src/Ai/Providers/AnthropicProvider.php` — Anthropic Claude support
- `src/Ai/Providers/OllamaProvider.php` — Ollama local LLM support

### Modified files
- `src/config/app.php` — new `ai` section with provider selection + per-provider config
- `src/BoilerplateServiceProvider.php` — register `boilerplate.ai.providers` singleton
- `src/Controllers/GptController.php` — `stream()` delegates to `AiStreamer`; `sendRequest()` removed
- `src/View/Composers/TinymceLoadComposer.php` — inject `$aiEnabled` variable
- `src/resources/views/load/tinymce.blade.php` — use `$aiEnabled` instead of OpenAI config check
- `src/resources/assets/js/vendor/tinymce/plugins/gpt/generator.js` — parse normalized SSE payload

## Configuration examples

**Using default OpenAI (backward compatible):**
```env
OPENAI_API_KEY=sk-...
```

**Using Anthropic Claude:**
```env
AI_PROVIDER=anthropic
ANTHROPIC_API_KEY=sk-ant-...
ANTHROPIC_MODEL=claude-3-5-haiku-20241022
```

**Using Ollama (local):**
```env
AI_PROVIDER=ollama
OLLAMA_ENDPOINT=http://localhost:11434
OLLAMA_MODEL=llama3
```

**Custom provider:**
```php
// AppServiceProvider::boot()
app('boilerplate.ai.providers')->registerAiProvider(\App\Ai\MyProvider::class);
```

## Test plan

- ✅ All existing tests pass (232 tests)
- ✅ Coding standards pass
- Test OpenAI with existing config (`OPENAI_API_KEY` only) — button visible, generation works
- Test Anthropic with `AI_PROVIDER=anthropic` and `ANTHROPIC_API_KEY`
- Test Ollama with `AI_PROVIDER=ollama` and `OLLAMA_MODEL` set (no API key needed)
- Test with no provider configured — GPT button absent from TinyMCE
- Test custom provider registration in consuming application